### PR TITLE
fix(snapshot-id): make entity id for snapshot not unique

### DIFF
--- a/gdcdatamodel/models/submission.py
+++ b/gdcdatamodel/models/submission.py
@@ -185,15 +185,20 @@ class TransactionSnapshot(Base):
         return doc
 
     id = Column(
-        Text,
+        Integer,
         primary_key=True,
+    )
+
+    entity_id = Column(
+        Text,
         nullable=False,
+        index=True,
     )
 
     transaction_id = Column(
         Integer,
         ForeignKey('transaction_logs.id'),
-        primary_key=True,
+        index=True,
     )
 
     action = Column(


### PR DESCRIPTION
* Make entity ID a separate and non-unique column on transaction snapshots.
* Change the ID column to be a real internal primary key.