### PR TITLE
import postgresql not postgres

### DIFF
--- a/gdcdatamodel/models/notifications.py
+++ b/gdcdatamodel/models/notifications.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, Text, DateTime, text, Boolean
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.dialects.postgres import ARRAY
+from sqlalchemy.dialects.postgresql import ARRAY
 
 import json
 

--- a/gdcdatamodel/models/reports.py
+++ b/gdcdatamodel/models/reports.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Text, DateTime, text, Integer, Index, func
-from sqlalchemy.dialects.postgres import JSONB
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
 

--- a/gdcdatamodel/models/submission.py
+++ b/gdcdatamodel/models/submission.py
@@ -9,7 +9,7 @@ Models for submission TransactionLogs
 from datetime import datetime
 from json import loads, dumps
 from sqlalchemy import func
-from sqlalchemy.dialects.postgres import JSONB
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship, deferred

--- a/gdcdatamodel/models/versioned_nodes.py
+++ b/gdcdatamodel/models/versioned_nodes.py
@@ -1,5 +1,5 @@
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.dialects.postgres import ARRAY, JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy import Column, Text, DateTime, BigInteger, text, Index
 from copy import copy
 


### PR DESCRIPTION
postgres dialect renamed postgresql in sqlalchemy 0.6: 
https://docs.sqlalchemy.org/en/13/changelog/changelog_06.html#change-0ce9ee480a5a66cb9f77e0207f6dfc70

In 1.1 "postgres" is finally being removed:
https://docs.sqlalchemy.org/en/13/changelog/migration_11.html#the-postgres-module-is-removed 

