### PR TITLE
Set autoincrement true in transaction_documents id

### DIFF
--- a/gdcdatamodel/models/submission.py
+++ b/gdcdatamodel/models/submission.py
@@ -250,6 +250,7 @@ class TransactionDocument(Base):
     id = Column(
         Integer,
         primary_key=True,
+        autoincrement=True,
         nullable=False,
     )
 


### PR DESCRIPTION
https://docs.sqlalchemy.org/en/11/changelog/migration_11.html#the-autoincrement-directive-is-no-longer-implicitly-enabled-for-a-composite-primary-key-column 

So just explicitly set `autoincrement=True` on the `id` column in `transaction_documents`

<!--Seems to be neither a "bug fix" nor an "improvement"... -->

<!-- ### Bug Fixes

### Improvements -->


